### PR TITLE
Add option to copy rather than move a package in the stage method

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ response: 201 CREATED, 404 NOT FOUND (source rpm not found), 409 CONFLICT (rpm a
 
 
 
+### copy rpm to another repo
+```curl -X COPY $HOST/admin/v1/repos/SOURCE_REPO/RPM?stageto=TARGET_REPO```
+
+response: 201 CREATED, 404 NOT FOUND (source rpm not found), 409 CONFLICT (rpm already present in target repo)
+
+
+
 ### delete empty repo
 ```curl -X DELETE $HOST/admin/v1/repos/OBSOLETE_REPO```
 

--- a/src/main/python/yumrepos/app.py
+++ b/src/main/python/yumrepos/app.py
@@ -77,7 +77,7 @@ def add_admin_routes(app, backend):
 
         return "%s not a valid rpm" % rpm_file.filename, 400
 
-    @admin.route('/repos/<path:reponame>/<rpmname>.rpm', methods=['STAGE'])
+    @admin.route('/repos/<path:reponame>/<rpmname>.rpm', methods=['STAGE', 'COPY'])
     def stage_rpm(reponame, rpmname):
         rpmname = rpmname + ".rpm"
         if not backend.exists(reponame, rpmname):
@@ -88,7 +88,7 @@ def add_admin_routes(app, backend):
             return "target repo '%s' does not exist" % targetreponame, 404
         if backend.exists(targetreponame, rpmname):
             abort(409)
-        return backend.stage(reponame, rpmname, targetreponame)
+        return backend.stage(reponame, rpmname, targetreponame, copy=request.method == 'COPY')
 
     @admin.route('/repos/<path:reponame>/<rpmname>.rpm', methods=['GET'])
     def get_rpm_info(reponame, rpmname):

--- a/src/main/python/yumrepos/fs_backend.py
+++ b/src/main/python/yumrepos/fs_backend.py
@@ -267,9 +267,12 @@ class FsBackend(object):
         filename = self._to_path(path)
         return os.path.isfile(filename) and os.path.exists(filename)
 
-    def stage(self, source, rpm, target):
-        shutil.move(self._to_path(source, rpm), self._to_path(target, rpm))
-        self.create_repo_metadata(source)
+    def stage(self, source, rpm, target, copy=False):
+        if copy:
+            shutil.copy(self._to_path(source, rpm), self._to_path(target, rpm))
+        else:
+            shutil.move(self._to_path(source, rpm), self._to_path(target, rpm))
+            self.create_repo_metadata(source)
         self.create_repo_metadata(target)
         return '', 201
 

--- a/src/unittest/resources/full-lifecycle-tests
+++ b/src/unittest/resources/full-lifecycle-tests
@@ -147,6 +147,12 @@ $CURL -X STAGE $HOST/admin/v1/repos/$TESTREPO1/$TESTRPM?stageto=unknown-repo -i 
 echo "stage testrpm to testrepo2"
 $CURL -X STAGE $HOST/admin/v1/repos/$TESTREPO1/$TESTRPM?stageto=testrepo2
 
+echo "copy testrpm to testrepo2"
+$CURL -X COPY $HOST/admin/v1/repos/$TESTREPO1/$TESTRPM?stageto=testrepo3
+
+echo "delete up testrpm from testrepo3"
+$CURL -X DELETE $HOST/admin/v1/repos/$TESTREPO3/$TESTRPM -i -s | $CHECK_STATE "204 NO CONTENT"
+
 if $TEST_YUM; then
     echo "search for rpm via yum"
     $YUM clean all


### PR DESCRIPTION
For example, if you wanted to promote an RPM from a `staging` repo to a `production` repo.