### PR TITLE
fix copyto vs. stageto GET parameter for COPY

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ response: 201 CREATED, 404 NOT FOUND (source rpm not found), 409 CONFLICT (rpm a
 
 
 ### copy rpm to another repo
-```curl -X COPY $HOST/admin/v1/repos/SOURCE_REPO/RPM?stageto=TARGET_REPO```
+```curl -X COPY $HOST/admin/v1/repos/SOURCE_REPO/RPM?copyto=TARGET_REPO```
 
 response: 201 CREATED, 404 NOT FOUND (source rpm not found), 409 CONFLICT (rpm already present in target repo)
 


### PR DESCRIPTION
First off: thanks for this awesome project!

Everything works beautifully, except for one small thing: The readme states to use the `stageto` GET parameter for both the `COPY` and `STAGE` method. The code in [`app.py#L120`](https://github.com/arnehilmann/yumrepos/blob/master/src/main/python/yumrepos/app.py#L120) only accepts `copyto` for `COPY`.

This adapts the README to match the implementation.